### PR TITLE
Fix RtcConfiguration format

### DIFF
--- a/teleop-vue/src/store/modules/opentera/init.ts
+++ b/teleop-vue/src/store/modules/opentera/init.ts
@@ -1,5 +1,5 @@
 import openteraWebrtcWebClient from "opentera-webrtc-web-client";
-import { RtcConfiguration, SignalingServerConfirguration, StreamConfiguration } from "./types";
+import { IceServer, RtcConfiguration, SignalingServerConfirguration, StreamConfiguration } from "./types";
 import { getBasePath, getOrigin } from "@/config/location";
 import { getSignalingServerURL } from "./utils";
 
@@ -27,9 +27,10 @@ export function initDataChannelConfiguration() : any {
 export async function initRtcConfiguration(password? : string) : Promise<RtcConfiguration> {
     return new Promise<RtcConfiguration>((resolve , reject) => {
         const url = process.env.NODE_ENV !== "production" ? getOrigin() + getBasePath() + "/iceservers.json" : getSignalingServerURL() + "/iceservers";
-        console.log("Fetch ice servers from: ", url);
         openteraWebrtcWebClient.iceServers.fetchFromServer(url, password)
-            .then((config : RtcConfiguration) => resolve(config))
+            .then((config : Array<IceServer>) => resolve({
+                iceServers: config,
+            }))
             .catch((err: Error) => reject(err));
     });
 }

--- a/teleop-vue/src/store/modules/opentera/init.ts
+++ b/teleop-vue/src/store/modules/opentera/init.ts
@@ -27,6 +27,7 @@ export function initDataChannelConfiguration() : any {
 export async function initRtcConfiguration(password? : string) : Promise<RtcConfiguration> {
     return new Promise<RtcConfiguration>((resolve , reject) => {
         const url = process.env.NODE_ENV !== "production" ? getOrigin() + getBasePath() + "/iceservers.json" : getSignalingServerURL() + "/iceservers";
+        console.log("Fetch ice servers from: ", url);
         openteraWebrtcWebClient.iceServers.fetchFromServer(url, password)
             .then((config : RtcConfiguration) => resolve(config))
             .catch((err: Error) => reject(err));

--- a/teleop-vue/src/store/modules/opentera/opentera.ts
+++ b/teleop-vue/src/store/modules/opentera/opentera.ts
@@ -83,6 +83,8 @@ const Opentera = {
       const dataChannelConfiguration = initDataChannelConfiguration();
       const rtcConfiguration = await initRtcConfiguration(payload.password).catch(err => context.state.logger(err));
 
+      console.log("loaded ice servers: ", rtcConfiguration);
+
       context.commit(
         "setStreamClient",
         new openteraWebrtcWebClient.StreamDataChannelClient(

--- a/teleop-vue/src/store/modules/opentera/types.ts
+++ b/teleop-vue/src/store/modules/opentera/types.ts
@@ -14,9 +14,16 @@ export interface StreamConfiguration {
     localStream?: MediaStream;
     isSendOnly: boolean;
 }
+
+export interface IceServer {
+    urls: string;
+    username?: string;
+    credential?: string;
+    credentialType?: string;
+}
   
 export interface RtcConfiguration {
-    iceServers: [{ urls: string }];
+    iceServers: Array<IceServer>;
 }
   
 export type StreamDataChannelClient = typeof openteraWebrtcWebClient.StreamDataChannelClient;


### PR DESCRIPTION
Also add stronger typing for RtcConfiguration.
Be sure to rename your RTCIceServer argument `url` to `urls` since it's now deprecated; see https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer for more information.